### PR TITLE
fix(collection): ensure proper deletion

### DIFF
--- a/Resources/public/dynamic-collection.js
+++ b/Resources/public/dynamic-collection.js
@@ -37,7 +37,7 @@ jQuery(document).ready(function() {
                 url: Routing.generate('collection-delete', {entityName: $(this).data('entityname'), id: $(this).data('id')}),
                 data: {},
                 success: function () {
-                    location.reload();
+                    location.reload(true);
                 }
             });
         }


### PR DESCRIPTION
On Firefox, location.reload renders the page from cache. https://developer.mozilla.org/fr/docs/Web/API/Location/reload#location.reload_na_pas_de_param%C3%A8tre